### PR TITLE
Handlers displayed extra text

### DIFF
--- a/logstash.py
+++ b/logstash.py
@@ -116,8 +116,12 @@ class CallbackModule(CallbackBase):
         }
         self.logger.info(json.dumps(summarize_stat), extra = data)
 
+    '''
+    Tasks and handler tasks are dealt with here
+    '''
     def v2_runner_on_ok(self, result, **kwargs):
         task_name = str(result._task).replace('TASK: ','')
+        task_name = str(result._task).replace('HANDLER: ','')
         if task_name == 'setup':
             data = {
                 'status': "OK",
@@ -134,7 +138,6 @@ class CallbackModule(CallbackBase):
                 changed = result._result['changed']
             else:
                 changed = False
-
             data = {
                 'status': "OK",
                 'host': self.hostname,


### PR DESCRIPTION
Prior to this commit, handlers would display text such as

        "ansible_task" => "HANDLER: pgporada.ntp : Restart ntp",

Handlers are now displayed as follows

        "ansible_task" => "pgporada.ntp : Restart ntp",
