### PR TITLE
Flake8 fixes and play name output

### DIFF
--- a/logstash.py
+++ b/logstash.py
@@ -121,10 +121,27 @@ class CallbackModule(CallbackBase):
 
     def v2_playbook_on_play_start(self, play):
         self.play_id = str(play._uuid)
+
+        """
+        play.name, if not specified in the playbook, will use the value of the line containing the - (yaml indent)
+        Example:
+
+        ---
+        - name: Play 1
+          hosts: all
+          roles:
+            - whatever.thing
+
+        - hosts: localhost
+          connection: local
+          roles:
+            - whatever.thing
+        ...
+
+        would produce play.name of "Play 1" and "localhost"
+        """
         if play.name:
             self.play_name = play.name
-        else:
-            self.play_name = "WARNING: Play name was not set"
 
         data = {
             'status': "OK",

--- a/logstash.py
+++ b/logstash.py
@@ -33,6 +33,7 @@ except ImportError:
 
 from ansible.plugins.callback import CallbackBase
 
+
 class CallbackModule(CallbackBase):
     """
     ansible logstash callback plugin
@@ -71,7 +72,7 @@ class CallbackModule(CallbackBase):
             self._display.warning("The required python-logstash is not installed. "
                 "pip install python-logstash")
         else:
-            self.logger =  logging.getLogger('python-logstash-logger')
+            self.logger = logging.getLogger('python-logstash-logger')
             self.logger.setLevel(logging.DEBUG)
 
             self.handler = logstash.TCPLogstashHandler(
@@ -96,7 +97,7 @@ class CallbackModule(CallbackBase):
             'ansible_type': "start",
             'ansible_playbook': self.playbook,
         }
-        self.logger.info("START " + self.playbook, extra = data)
+        self.logger.info("START " + self.playbook, extra=data)
 
     def v2_playbook_on_stats(self, stats):
         summarize_stat = {}
@@ -117,7 +118,7 @@ class CallbackModule(CallbackBase):
             'ansible_pre_command_output': self.pre_command_output,
             'ansible_result': json.dumps(summarize_stat), # deprecated field
         }
-        self.logger.info(json.dumps(summarize_stat), extra = data)
+        self.logger.info(json.dumps(summarize_stat), extra=data)
 
     def v2_playbook_on_play_start(self, play):
         self.play_id = str(play._uuid)
@@ -160,8 +161,8 @@ class CallbackModule(CallbackBase):
     Tasks and handler tasks are dealt with here
     '''
     def v2_runner_on_ok(self, result, **kwargs):
-        task_name = str(result._task).replace('TASK: ','')
-        task_name = str(result._task).replace('HANDLER: ','')
+        task_name = str(result._task).replace('TASK: ', '')
+        task_name = str(result._task).replace('HANDLER: ', '')
         if task_name == 'setup':
             data = {
                 'status': "OK",
@@ -174,7 +175,7 @@ class CallbackModule(CallbackBase):
                 'ansible_host': result._host.name,
                 'ansible_task': task_name,
                 'ansible_pre_command_output': self.pre_command_output,
-                'ansible_facts': self._dump_results(result._result) # deprecated field
+                'ansible_facts': self._dump_results(result._result)  # deprecated field
             }
         else:
             if 'changed' in result._result.keys():
@@ -194,12 +195,12 @@ class CallbackModule(CallbackBase):
                 'ansible_task': task_name,
                 'ansible_task_id': self.task_id,
                 'ansible_pre_command_output': self.pre_command_output,
-                'ansible_result': self._dump_results(result._result) # deprecated field
+                'ansible_result': self._dump_results(result._result)  # deprecated field
             }
-        self.logger.info(self._dump_results(result._result), extra = data)
+        self.logger.info(self._dump_results(result._result), extra=data)
 
     def v2_runner_on_skipped(self, result, **kwargs):
-        task_name = str(result._task).replace('TASK: ','')
+        task_name = str(result._task).replace('TASK: ', '')
         data = {
             'status': "SKIPPED",
             'host': self.hostname,
@@ -213,7 +214,7 @@ class CallbackModule(CallbackBase):
             'ansible_pre_command_output': self.pre_command_output,
             'ansible_host': result._host.name
         }
-        self.logger.info("SKIPPED " + task_name, extra = data)
+        self.logger.info("SKIPPED " + task_name, extra=data)
 
     def v2_playbook_on_import_for_host(self, result, imported_file):
         data = {
@@ -228,7 +229,7 @@ class CallbackModule(CallbackBase):
             'ansible_pre_command_output': self.pre_command_output,
             'imported_file': imported_file
         }
-        self.logger.info("IMPORT " + imported_file, extra = data)
+        self.logger.info("IMPORT " + imported_file, extra=data)
 
     def v2_playbook_on_not_import_for_host(self, result, missing_file):
         data = {
@@ -243,14 +244,15 @@ class CallbackModule(CallbackBase):
             'ansible_pre_command_output': self.pre_command_output,
             'missing_file': missing_file
         }
-        self.logger.info("NOT IMPORTED " + missing_file, extra = data)
+        self.logger.info("NOT IMPORTED " + missing_file, extra=data)
 
     def v2_runner_on_failed(self, result, **kwargs):
-        task_name = str(result._task).replace('TASK: ','')
+        task_name = str(result._task).replace('TASK: ', '')
         if 'changed' in result._result.keys():
             changed = result._result['changed']
         else:
             changed = False
+
         data = {
             'status': "FAILED",
             'host': self.hostname,
@@ -264,13 +266,13 @@ class CallbackModule(CallbackBase):
             'ansible_task': task_name,
             'ansible_task_id': self.task_id,
             'ansible_pre_command_output': self.pre_command_output,
-            'ansible_result': self._dump_results(result._result) # deprecated field
+            'ansible_result': self._dump_results(result._result)  # deprecated field
         }
         self.errors += 1
-        self.logger.error(self._dump_results(result._result), extra = data)
+        self.logger.error(self._dump_results(result._result), extra=data)
 
     def v2_runner_on_unreachable(self, result, **kwargs):
-        task_name = str(result._task).replace('TASK: ','')
+        task_name = str(result._task).replace('TASK: ', '')
         data = {
             'status': "UNREACHABLE",
             'host': self.hostname,
@@ -283,12 +285,12 @@ class CallbackModule(CallbackBase):
             'ansible_task': task_name,
             'ansible_task_id': self.task_id,
             'ansible_pre_command_output': self.pre_command_output,
-            'ansible_result': self._dump_results(result._result) # deprecated field
+            'ansible_result': self._dump_results(result._result)  # deprecated field
         }
-        self.logger.error(self._dump_results(result._result), extra = data)
+        self.logger.error(self._dump_results(result._result), extra=data)
 
     def v2_runner_on_async_failed(self, result, **kwargs):
-        task_name = str(result._task).replace('TASK: ','')
+        task_name = str(result._task).replace('TASK: ', '')
         data = {
             'status': "FAILED",
             'host': self.hostname,
@@ -301,7 +303,7 @@ class CallbackModule(CallbackBase):
             'ansible_task': task_name,
             'ansible_task_id': self.task_id,
             'ansible_pre_command_output': self.pre_command_output,
-            'ansible_result': self._dump_results(result._result) # deprecated field
+            'ansible_result': self._dump_results(result._result)  # deprecated field
         }
         self.errors += 1
-        self.logger.error(self._dump_results(result._result), extra = data)
+        self.logger.error(self._dump_results(result._result), extra=data)

--- a/logstash.py
+++ b/logstash.py
@@ -152,6 +152,7 @@ class CallbackModule(CallbackBase):
             'ansible_play_id': self.play_id,
             'ansible_play_name': self.play_name,
         }
+        self.logger.info("START PLAY", extra=data)
 
     def v2_playbook_on_task_start(self, task, is_conditional):
         self.task_id = str(task._uuid)

--- a/logstash.py
+++ b/logstash.py
@@ -14,7 +14,6 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
-
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
@@ -22,7 +21,6 @@ import os
 import json
 import socket
 import uuid
-
 import logging
 
 try:
@@ -116,7 +114,7 @@ class CallbackModule(CallbackBase):
             'ansible_type': "finish",
             'ansible_playbook': self.playbook,
             'ansible_pre_command_output': self.pre_command_output,
-            'ansible_result': json.dumps(summarize_stat), # deprecated field
+            'ansible_result': json.dumps(summarize_stat)  # deprecated field
         }
         self.logger.info(json.dumps(summarize_stat), extra=data)
 

--- a/logstash.py
+++ b/logstash.py
@@ -121,6 +121,20 @@ class CallbackModule(CallbackBase):
 
     def v2_playbook_on_play_start(self, play):
         self.play_id = str(play._uuid)
+        if play.name:
+            self.play_name = play.name
+        else:
+            self.play_name = "WARNING: Play name was not set"
+
+        data = {
+            'status': "OK",
+            'host': self.hostname,
+            'session': self.session,
+            'ansible_type': "start",
+            'ansible_playbook': self.playbook,
+            'ansible_play_id': self.play_id,
+            'ansible_play_name': self.play_name,
+        }
 
     def v2_playbook_on_task_start(self, task, is_conditional):
         self.task_id = str(task._uuid)
@@ -137,6 +151,7 @@ class CallbackModule(CallbackBase):
                 'host': self.hostname,
                 'session': self.session,
                 'ansible_play_id': self.play_id,
+                'ansible_play_name': self.play_name,
                 'ansible_type': "setup",
                 'ansible_playbook': self.playbook,
                 'ansible_host': result._host.name,
@@ -154,6 +169,7 @@ class CallbackModule(CallbackBase):
                 'host': self.hostname,
                 'session': self.session,
                 'ansible_play_id': self.play_id,
+                'ansible_play_name': self.play_name,
                 'ansible_changed': changed,
                 'ansible_type': "task",
                 'ansible_playbook': self.playbook,
@@ -172,6 +188,7 @@ class CallbackModule(CallbackBase):
             'host': self.hostname,
             'session': self.session,
             'ansible_play_id': self.play_id,
+            'ansible_play_name': self.play_name,
             'ansible_type': "task",
             'ansible_playbook': self.playbook,
             'ansible_task': task_name,
@@ -187,6 +204,7 @@ class CallbackModule(CallbackBase):
             'host': self.hostname,
             'session': self.session,
             'ansible_play_id': self.play_id,
+            'ansible_play_name': self.play_name,
             'ansible_type': "import",
             'ansible_playbook': self.playbook,
             'ansible_host': result._host.name,
@@ -201,6 +219,7 @@ class CallbackModule(CallbackBase):
             'host': self.hostname,
             'session': self.session,
             'ansible_play_id': self.play_id,
+            'ansible_play_name': self.play_name,
             'ansible_type': "import",
             'ansible_playbook': self.playbook,
             'ansible_host': result._host.name,
@@ -220,6 +239,7 @@ class CallbackModule(CallbackBase):
             'host': self.hostname,
             'session': self.session,
             'ansible_play_id': self.play_id,
+            'ansible_play_name': self.play_name,
             'ansible_changed': changed,
             'ansible_type': "task",
             'ansible_playbook': self.playbook,
@@ -239,6 +259,7 @@ class CallbackModule(CallbackBase):
             'host': self.hostname,
             'session': self.session,
             'ansible_play_id': self.play_id,
+            'ansible_play_name': self.play_name,
             'ansible_type': "task",
             'ansible_playbook': self.playbook,
             'ansible_host': result._host.name,
@@ -256,6 +277,7 @@ class CallbackModule(CallbackBase):
             'host': self.hostname,
             'session': self.session,
             'ansible_play_id': self.play_id,
+            'ansible_play_name': self.play_name,
             'ansible_type': "task",
             'ansible_playbook': self.playbook,
             'ansible_host': result._host.name,

--- a/logstash.py
+++ b/logstash.py
@@ -84,7 +84,7 @@ class CallbackModule(CallbackBase):
             self.logger.addHandler(self.handler)
             self.hostname = socket.gethostname()
             self.session = str(uuid.uuid1())
-            self.pre_command_output = os.popen(os.getenv("LOGSTASH_PRE_COMMAND", "ansible --version | head -1")).read()
+            self.pre_command_output = os.popen(os.getenv("LOGSTASH_PRE_COMMAND", "ansible --version | head -1 | tr '\n' ' ' | sed -e 's/ansible//gI' -e 's/[[:space:]]//g'")).read()
             self.errors = 0
 
     def v2_playbook_on_start(self, playbook):

--- a/logstash.py
+++ b/logstash.py
@@ -68,7 +68,7 @@ class CallbackModule(CallbackBase):
         if not HAS_LOGSTASH:
             self.disabled = True
             self._display.warning("The required python-logstash is not installed. "
-                "pip install python-logstash")
+                                  "pip install python-logstash")
         else:
             self.logger = logging.getLogger('python-logstash-logger')
             self.logger.setLevel(logging.DEBUG)
@@ -83,7 +83,8 @@ class CallbackModule(CallbackBase):
             self.logger.addHandler(self.handler)
             self.hostname = socket.gethostname()
             self.session = str(uuid.uuid1())
-            self.pre_command_output = os.popen(os.getenv("LOGSTASH_PRE_COMMAND", "ansible --version | head -1 | tr '\n' ' ' | sed -e 's/ansible//gI' -e 's/[[:space:]]//g'")).read()
+            self.pre_command_output = os.popen(os.getenv(
+                "LOGSTASH_PRE_COMMAND", "ansible --version | head -1 | tr '\n' ' ' | sed -e 's/ansible//gI' -e 's/[[:space:]]//g'")).read()
             self.errors = 0
 
     def v2_playbook_on_start(self, playbook):
@@ -158,6 +159,7 @@ class CallbackModule(CallbackBase):
     '''
     Tasks and handler tasks are dealt with here
     '''
+
     def v2_runner_on_ok(self, result, **kwargs):
         task_name = str(result._task).replace('TASK: ', '')
         task_name = str(result._task).replace('HANDLER: ', '')
@@ -173,7 +175,8 @@ class CallbackModule(CallbackBase):
                 'ansible_host': result._host.name,
                 'ansible_task': task_name,
                 'ansible_pre_command_output': self.pre_command_output,
-                'ansible_facts': self._dump_results(result._result)  # deprecated field
+                # deprecated field
+                'ansible_facts': self._dump_results(result._result)
             }
         else:
             if 'changed' in result._result.keys():
@@ -193,7 +196,8 @@ class CallbackModule(CallbackBase):
                 'ansible_task': task_name,
                 'ansible_task_id': self.task_id,
                 'ansible_pre_command_output': self.pre_command_output,
-                'ansible_result': self._dump_results(result._result)  # deprecated field
+                # deprecated field
+                'ansible_result': self._dump_results(result._result)
             }
         self.logger.info(self._dump_results(result._result), extra=data)
 
@@ -264,7 +268,8 @@ class CallbackModule(CallbackBase):
             'ansible_task': task_name,
             'ansible_task_id': self.task_id,
             'ansible_pre_command_output': self.pre_command_output,
-            'ansible_result': self._dump_results(result._result)  # deprecated field
+            # deprecated field
+            'ansible_result': self._dump_results(result._result)
         }
         self.errors += 1
         self.logger.error(self._dump_results(result._result), extra=data)
@@ -283,7 +288,8 @@ class CallbackModule(CallbackBase):
             'ansible_task': task_name,
             'ansible_task_id': self.task_id,
             'ansible_pre_command_output': self.pre_command_output,
-            'ansible_result': self._dump_results(result._result)  # deprecated field
+            # deprecated field
+            'ansible_result': self._dump_results(result._result)
         }
         self.logger.error(self._dump_results(result._result), extra=data)
 
@@ -301,7 +307,8 @@ class CallbackModule(CallbackBase):
             'ansible_task': task_name,
             'ansible_task_id': self.task_id,
             'ansible_pre_command_output': self.pre_command_output,
-            'ansible_result': self._dump_results(result._result)  # deprecated field
+            # deprecated field
+            'ansible_result': self._dump_results(result._result)
         }
         self.errors += 1
         self.logger.error(self._dump_results(result._result), extra=data)


### PR DESCRIPTION
I fixed a bunch of flake8 warnings. I also was able to capture the play name and output that. I switched the ansible version to has specifically the number instead of "ansible 2.2.1.0\n"

Here's an example output blob

```
{
                  "ansible_type" => "task",
                         "level" => "INFO",
                "ansible_result" => "{\"changed\": false, \"msg\": \"\", \"rc\": 0, \"results\": [\"epel-release-6-8.noarch providing epel-release is already installed\"]}",
                       "session" => "83eefdc4-f8b7-11e6-b7a1-e4115b24f077",
               "ansible_changed" => false,
               "ansible_play_id" => "442bc66b-ed77-4b81-b9fd-fe62858db0a0",
                       "message" => "{\"changed\": false, \"msg\": \"\", \"rc\": 0, \"results\": [\"epel-release-6-8.noarch providing epel-release is already installed\"]}",
                          "type" => "ansible",
              "ansible_playbook" => "/tmp/kitchen/default.yml",
                  "ansible_task" => "TASK: pgporada.repo-epel : Install EPEL repo",
                          "tags" => [],
                          "path" => "/tmp/kitchen/callback_plugins/logstash.py",
               "ansible_task_id" => "68c8a7a7-da33-4dfb-8e6b-65267b7d5139",
                  "ansible_host" => "localhost",
             "ansible_play_name" => "Install EPEL repository",
                    "@timestamp" => 2017-02-22T04:29:37.222Z,
    "ansible_pre_command_output" => "2.2.0.0",
                          "port" => 60472,
                          "host" => "laptappy",
                      "@version" => "1",
                   "logger_name" => "python-logstash-logger",
                        "status" => "OK"
}
{
                  "ansible_type" => "task",
                         "level" => "INFO",
                "ansible_result" => "{\"changed\": true, \"cmd\": \"uptime\", \"delta\": \"0:00:00.070225\", \"end\": \"2017-02-22 04:29:39.078450\", \"rc\": 0, \"start\": \"2017-02-22 04:29:39.008225\", \"stderr\": \"\", \"stdout\": \" 04:29:39 up  2:41,  0 users,  load average: 2.66, 1.25, 1.04\", \"stdout_lines\": [\" 04:29:39 up  2:41,  0 users,  load average: 2.66, 1.25, 1.04\"], \"warnings\": []}",
                       "session" => "83eefdc4-f8b7-11e6-b7a1-e4115b24f077",
               "ansible_changed" => true,
               "ansible_play_id" => "0c8874f0-bf02-4ab4-8089-e29ffffa592f",
                       "message" => "{\"changed\": true, \"cmd\": \"uptime\", \"delta\": \"0:00:00.070225\", \"end\": \"2017-02-22 04:29:39.078450\", \"rc\": 0, \"start\": \"2017-02-22 04:29:39.008225\", \"stderr\": \"\", \"stdout\": \" 04:29:39 up  2:41,  0 users,  load average: 2.66, 1.25, 1.04\", \"stdout_lines\": [\" 04:29:39 up  2:41,  0 users,  load average: 2.66, 1.25, 1.04\"], \"warnings\": []}",
                          "type" => "ansible",
              "ansible_playbook" => "/tmp/kitchen/default.yml",
                  "ansible_task" => "TASK: Thing",
                          "tags" => [],
                          "path" => "/tmp/kitchen/callback_plugins/logstash.py",
               "ansible_task_id" => "33b37e0e-bcc9-4369-8bb0-cd23ba262417",
                  "ansible_host" => "localhost",
             "ansible_play_name" => "localhost",
                    "@timestamp" => 2017-02-22T04:29:39.094Z,
    "ansible_pre_command_output" => "2.2.0.0",
                          "port" => 60472,
                          "host" => "laptappy",
                      "@version" => "1",
                   "logger_name" => "python-logstash-logger",
                        "status" => "OK"
}
{
                  "ansible_type" => "finish",
                         "level" => "INFO",
                "ansible_result" => "{\"localhost\": {\"unreachable\": 0, \"skipped\": 0, \"ok\": 5, \"changed\": 1, \"failures\": 0}}",
                       "session" => "83eefdc4-f8b7-11e6-b7a1-e4115b24f077",
                       "message" => "{\"localhost\": {\"unreachable\": 0, \"skipped\": 0, \"ok\": 5, \"changed\": 1, \"failures\": 0}}",
                          "type" => "ansible",
              "ansible_playbook" => "/tmp/kitchen/default.yml",
                          "tags" => [],
                          "path" => "/tmp/kitchen/callback_plugins/logstash.py",
                    "@timestamp" => 2017-02-22T04:29:39.103Z,
    "ansible_pre_command_output" => "2.2.0.0",
                          "port" => 60472,
                          "host" => "laptappy",
                      "@version" => "1",
                   "logger_name" => "python-logstash-logger",
                        "status" => "OK"
}
```
