### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Put the `logstash` plugin from this git repository into the path_to_callback_plu
 This plugin makes use of the following environment variables:
 * `LOGSTASH_SERVER`        (optional): defaults to localhost
 * `LOGSTASH_PORT`          (optional): defaults to 5000
-* `LOGSTASH_TYPE`          (optional): defaults to ansible
+* `LOGSTASH_TYPE`          (optional): the Elk Index to use, defaults to "ansible"
 * `LOGSTASH_PRE_COMMAND`   (optional): defaults is "ansible --version | head -1" execute command before run and result put `ansible_pre_command_output` field
 
 Or you can use the `[callback_logstash]` section of your `ansible.cfg`


### PR DESCRIPTION
When implementing this, our team mistook 'LOGSTASH_TYPE' being set to 'ansible' to be a kind of data input or formatting rather than a destination index in Elk, which is what it is. I propose updating the description to include this information, as I know of several engineers who have not realised this and run into difficulties because of it.